### PR TITLE
Release v1.10.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,11 @@ RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
 #     && apt-get -y install --no-install-recommends <your-package-list-here> \
 #     && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update -y && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,8 @@
 	//"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && poetry install -E test",
 	// to enable git commands
 	"postStartCommand": {
-		"yarn_install": "yarn install --frozen-lockfile --prodution=false --non-interactive",
-		"yarn_develop": "yarn develop"
+		"yarn_install": "yarn install --frozen-lockfile --production=false --non-interactive",
+		// "yarn_develop": "yarn develop"
 		// "git_add_safe": "git config --global --add safe.directory ${containerWorkspaceFolder}",
 	},
 	// Features to add to the dev container. More info: https://containers.dev/implementors/features.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,8 +114,8 @@ jobs:
       # expectations for assertions
       expected_number_of_files: 50
       bundle_size: ${{ needs.gatsby.outputs.BUNDLE_SIZE }}
-      # other test data
-      bundle_size_acceptance: 2.4
+      # Configurable Acceptance Criteria: accept up to 2.5MB
+      bundle_size_acceptance: 2.5
 
   # LOGICAL AGGRGATION OF CI
   check:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-# CI/CD Pipeline for Gatsby/TS project, in GitHub Actions
+# CI/CD Pipeline
 
 # Test -> Build -> Deploy
 
@@ -6,7 +6,9 @@
 on:
   push:
     branches:
-      - "*"
+      - "main"
+      - "dev"
+      - "ci"
     # we use release branch for semver/changelog updates and deploying 'rc' tags
     # thus we filter out events for branch 'release', to NOT trigger
     # avoid triggering on sem ver bump / changelog update commits
@@ -17,11 +19,12 @@ on:
     tags:
       - v*
 
+# Note: env context only available as env vars in code, not in 'if' conditions!
+
 jobs:
-# CONFIGURE PIPELINE - to allow git-tracked logic for Jobs if/when to run
-# note: if in Jobs here, cannot access env context (can the vars)
-# can retire this Job if all ifs leverage vars for reading Top-Level overrides
+  # can retire this Job if all 'if' condition read values from 'vars' for determining Top-Level overrides
   pipe:
+  # CONFIGURE PIPELINE - to allow git-tracked logic for Jobs if/when to run
     uses: ./.github/workflows/pipe_config.yml
     with:
       ALLOW_LINT_TO_FAIL: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-          AWS_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
-        run: aws cloudfront create-invalidation --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" --paths /index.html
-            #  aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --debug --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths /index.html
+
+        # --paths "/*"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,12 +6,11 @@ on:
       target_ci_artifact:
         required: false
         type: string
-        description: 'CI Artifact with static website to audit'
+        description: 'CI Artifact with static website to audit. If provided, will run a simple file server to serve the static site files download from CI Artifact. Mutually exclusive with target_url input.'
       target_url:
         required: false
         type: string
-        description: 'URL to audit'
-      # REQUIRED
+        description: 'URL to audit. If provided, will run Lighthouse CI against this public URL. Mutually exclusive with target_ci_artifact input.'
 
 jobs:
   lighthouse:
@@ -43,10 +42,7 @@ jobs:
       # Healthcheck
       - run: lhci healthcheck
 
-      - name: Derive Lighthouse CLI flags from inputs
-        # if input url use --url and value
-        # if input ci artifact, will will download and serve the artifact later
-        # else exit with error msg and 1 exit code
+      - name: 'Derive whether to Audit Static Dist Dir or public URL, from inputs: --collect lhci flag argument'
         run: |
           if [ -n "${{ inputs.target_url }}" ]; then
             if [ -n "${{ inputs.target_ci_artifact }}" ]; then
@@ -62,6 +58,7 @@ jobs:
             echo "[INFO] Will audit Static Site from CI Artifact: ${{ inputs.target_ci_artifact }}"
           fi
 
+      # CI ARTIFACT DOWNLOAD
       - name: 'Download Website bundle (files) from CI Artifact'
         if: env.SINGAL_ARTIFACT == 'true'
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.0] - 21/12/2024
+
+### Changes
+
+#### Feature
+- use app Theme for color styles of Copy pop-up
+- simple Copied pop-up on shell cmd user copy
+- copy to clipboard on shell command click
+- style Introduction Section text
+
+#### CI
+- accept 2.5MB of prod build Bundle Size; a 4.17% increase from previous 2.4MB
+- improve inputs description for Headless Lighthouse Reusable Workflow
+- properly invalidate Cloudfront Distribution
+
+#### Test
+- update snapshots data
+
+#### Dev
+- add new story to examine Single Release Button inside a Reactive Grid
+- install make in Dev Container and run 'yarn install' at post Start
+
+
 ## [1.8.0] - 14/09/2024
 
 ### Changes

--- a/data-portfolio.yml
+++ b/data-portfolio.yml
@@ -169,7 +169,7 @@ projects:
     - PyPI
 
 - title: Python Software Release
-  development_period: May 2022
+  development_period: May 2022 - Jul 2022
   status: stable
   source_code_repo: boromir674/software-release
   resource_links:
@@ -185,7 +185,7 @@ projects:
       artifact_version: v0.1.0
   description: >
     A CLI that streamlines the process of making a "new" Software Release to
-    Github, using Semantic Versioning. Implemeted in Python, the CLI provides
+    Github, using Semantic Versioning. Implemented in Python, the CLI provides
     a wizard, that guides the user through the semi-automated "release process".
   tags:
     - Automated Software Release

--- a/data.yaml
+++ b/data.yaml
@@ -86,7 +86,7 @@ professional:
     - title: 'Tech Lead - Contractor'
       company: 'Eco Development S.A.'
       location: 'Fyliro - Thessaloniki, Greece'
-      duration: 'May 2023 - Present'
+      duration: 'May 2023 - Nov 2023'
       description: >
         Supervisor of the 'Data Analytics' team, responsible for the development of the company's Machine Learning Models and Data Pipelines Infrastructure.
       activities:
@@ -169,7 +169,7 @@ professional:
         - Increased web app security by implementing '2FA flow' involving 'QR-Code scanning'
         - Enabled sales for global customers in Australia, Indonesia, Hong-Kong and Singapore, by integrating our web app with the Invenco 3PL web API to periodically exchange data, using an authorized serverless app (AWS Lambda app)
         - Migrated web app's legacy "http polling" to real-time/event-driven solution  and achieve data exchange with the newly published Rakuten web API
-        - Enabled web app autoamated invoice generation and delivery to customers, with custom solution.
+        - Enabled web app automated invoice generation and delivery to customers, with custom solution.
         - Adding features for the IoT mobile (iOS \& Android) app, providing a UI to allow inter-device Bluetooth communication.
         - Developed a Terminal App, providing a Wizard to guide Bluetooth Device Testing on factory-site.
       technology_tags:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # environment:
     #   - PORT=8123
 
-  # Cypress container
+  # Run Headless Cypress CI: docker-compose run --build --rm cypress
   cypress:
     # the Docker image to use from https://github.com/cypress-io/cypress-docker-images
     # image: "cypress/included:3.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "konstantinos-lampridis-online",
-  "version": "1.6.3",
+  "version": "1.10.0",
   "private": true,
   "description": "konstantinos-lampridis-online",
   "author": "konstantinos",

--- a/src/Components/Portfolio/AppPortfolioItem.tsx
+++ b/src/Components/Portfolio/AppPortfolioItem.tsx
@@ -116,7 +116,7 @@ interface AppPortfolioItemProps {
 }
 
 const render = (d: PortfolioItemInterface, theme: AppPortfolioItemProps["theme"]) => {
-  console.log('theme', theme);
+  // console.log('theme', theme);
   return (
     <>
       <PortfolioItemProjectTitle theme={theme.projectTitle}>{d.title}</PortfolioItemProjectTitle>

--- a/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseButton.tsx
+++ b/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseButton.tsx
@@ -63,7 +63,6 @@ const SoftwareReleaseButton = styled.button<SoftwareReleaseButtonTheme>`
 
 
 const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme, data: { command, urlText }, children }) => {
-    console.log("Component");
     const [tooltipVisible, setTooltipVisible] = useState(false);
     const [copied, setCopied] = useState(false);
 
@@ -73,7 +72,6 @@ const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme,
     const tooltipRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
-        console.log("useEffect");
         // if the Tooltip is not visible, do nothing
         if (!tooltipVisible) {
             return;
@@ -82,7 +80,6 @@ const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme,
         const handleClickOutsideOfButtonAndTooltip = (event: MouseEvent) => {
             // Needs to exlcude Button, since we have the 'handleClickOnButton' listener on the button itself
             if (buttonRef.current && !buttonRef.current.contains(event.target as Node) && tooltipRef.current && !tooltipRef.current.contains(event.target as Node)) {
-                console.log("Clicked Outside of Button and Tooltip: Hiding Tooltip");
                 setTooltipVisible(false);
                 setZIndex(0);
             }
@@ -103,7 +100,6 @@ const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme,
     ///// Handle Click on the button /////
     const handleClickOnButton = () => {
         // if (!tooltipVisible) {
-            console.log("onClick Handler");
             setTooltipVisible(!tooltipVisible);
             // if visible set zIndex to 10 else 0
             setZIndex(tooltipVisible ? 0 : 10);
@@ -117,7 +113,6 @@ const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme,
 
     // Handle Click on the Command after Tooltip has appeared
     const handleCopyCommand = () => {
-        console.log("Copy Handler");
         navigator.clipboard.writeText(command).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000); // Hide the "copied" message after 2 seconds

--- a/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseButton.tsx
+++ b/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseButton.tsx
@@ -63,39 +63,71 @@ const SoftwareReleaseButton = styled.button<SoftwareReleaseButtonTheme>`
 
 
 const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme, data: { command, urlText }, children }) => {
+    console.log("Component");
     const [tooltipVisible, setTooltipVisible] = useState(false);
+    const [copied, setCopied] = useState(false);
+
     const { setZIndex } = useContext(ZIndexContext);
 
     const buttonRef = useRef<HTMLElement>(null);
     const tooltipRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
-        // Handle Click anywhere outside of the tooltip
-        const handleClickOutside = (event: MouseEvent) => {
-            if (
-                buttonRef.current && !buttonRef.current.contains(event.target as Node) &&
-                tooltipRef.current && !tooltipRef.current.contains(event.target as Node)
-            ) {
+        console.log("useEffect");
+        // if the Tooltip is not visible, do nothing
+        if (!tooltipVisible) {
+            return;
+          }
+        ///// Handle Click outside of the button and the tooltip /////
+        const handleClickOutsideOfButtonAndTooltip = (event: MouseEvent) => {
+            // Needs to exlcude Button, since we have the 'handleClickOnButton' listener on the button itself
+            if (buttonRef.current && !buttonRef.current.contains(event.target as Node) && tooltipRef.current && !tooltipRef.current.contains(event.target as Node)) {
+                console.log("Clicked Outside of Button and Tooltip: Hiding Tooltip");
                 setTooltipVisible(false);
+                setZIndex(0);
             }
+            // else if (buttonRef.current && buttonRef.current.contains(event.target as Node)) {
+            //     console.log("Clicked on Button: Hiding Tooltip");
+            //     setTooltipVisible(false);
+            //     setZIndex(0);
+            // }
         };
-
-        document.addEventListener("mousedown", handleClickOutside);
+        // Add Listener on Component Mount, only if the Tooltip is visible
+        document.addEventListener("mousedown", handleClickOutsideOfButtonAndTooltip);
         return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
+            // Remove Listener on Component Unmount
+            document.removeEventListener("mousedown", handleClickOutsideOfButtonAndTooltip);
         };
-    }, []);
+    }, [tooltipVisible]);
 
-    // Handle Click on the button
+    ///// Handle Click on the button /////
     const handleClickOnButton = () => {
-        setTooltipVisible(!tooltipVisible);
-        // if visible set zIndex to 10 else 0
-        setZIndex(tooltipVisible ? 0 : 10);
-      };
+        // if (!tooltipVisible) {
+            console.log("onClick Handler");
+            setTooltipVisible(!tooltipVisible);
+            // if visible set zIndex to 10 else 0
+            setZIndex(tooltipVisible ? 0 : 10);
+        // }
+    };
+
+    // Stop event propagation inside the tooltip
+    const handleTooltipClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+    };
+
+    // Handle Click on the Command after Tooltip has appeared
+    const handleCopyCommand = () => {
+        console.log("Copy Handler");
+        navigator.clipboard.writeText(command).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000); // Hide the "copied" message after 2 seconds
+        });
+    };
 
     return (
-        <div onClick={handleClickOnButton}>
+        <div>
             <SoftwareReleaseButton
+                onClick={handleClickOnButton}
                 ref={buttonRef as RefObject<HTMLButtonElement>}
                 color={theme.color}
                 backgroundColor={theme.backgroundColor}
@@ -106,13 +138,20 @@ const SoftwareReleaseButtonComponent: FC<SoftwareReleaseButtonProps> = ({ theme,
             </SoftwareReleaseButton>
             <SoftwareReleaseTooltip
                 ref={tooltipRef as RefObject<HTMLDivElement>}
+                onClick={handleTooltipClick}
                 visible={tooltipVisible} theme={{
                     color: theme.color,
                     backgroundColor: theme.backgroundColor,
                 }} data={{
                     urlText,
                     command,
-                }} />
+                }}
+                onCopyCommand={() => {
+                    handleCopyCommand();
+                    // handleTooltipClick();
+                }}
+                copied={copied}
+            />
         </div>
     );
 

--- a/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
+++ b/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
@@ -13,6 +13,9 @@ interface SoftwareReleaseTooltipProps {
         urlText: string;
     }
     visible: boolean;
+    onCopyCommand: () => void;
+    copied: boolean;
+    onClick: () => void;
 }
 
 // Inner Components
@@ -35,7 +38,7 @@ const MyLink = styled(Link)`
 `;
 
 // declared using forwardRef. This opts it into receiving the ref from above as the second ref argument which is declared after props.
-const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltipProps>(({ theme, data: { command, urlText }, visible }, ref) => {
+const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltipProps>(({ theme, data: { command, urlText }, visible, onCopyCommand, copied }, ref) => {
     if (!visible) return null;
 
     return (
@@ -54,12 +57,13 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
             }}
         >
             {/* SHELL COMMAND */}
-            <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px' }}>
+            <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px' }} onClick={onCopyCommand}>
                 <pre style={{ margin: 0 }}>
                     <code style={{ color: '#d63384' }}>
                         {command}
                     </code>
                 </pre>
+                {copied && <span style={{ color: 'green', marginLeft: '10px' }}>Copied!</span>}
             </div>
             {/* WEB PAGE URL */}
             <div style={{

--- a/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
+++ b/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
@@ -62,61 +62,6 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
                         {command}
                     </code>
                 </pre>
-                {/* OLD DESIGN */}
-                {/* {copied && <span style={{ color: 'green', marginLeft: '10px' }}>Copied!</span>} */}
-
-                {/* OPT 1 */}
-                {/* {copied && (
-                    <div style={{
-                        position: 'absolute',
-                        top: '-30px', // Adjust as needed
-                        left: '50%',
-                        transform: 'translateX(-50%)',
-                        padding: '5px 10px',
-                        backgroundColor: 'yellow',
-                        border: '1px solid black',
-                        borderRadius: '10px',
-                        boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
-                        zIndex: 1,
-                        whiteSpace: 'nowrap',
-                        fontSize: '12px',
-                        fontWeight: 'bold',
-                      }}>
-                    Copied!
-                    </div>
-                )} */}
-
-                {/* OPT 2 */}
-                {/* {copied && (
-                    <div style={{
-                        position: 'absolute',
-                        top: '50%',
-                        left: '-150px', // Adjust as needed
-                        transform: 'translateY(-50%)',
-                        padding: '5px 10px',
-                        backgroundColor: 'yellow',
-                        border: '1px solid black',
-                        borderRadius: '10px',
-                        boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
-                        zIndex: 1,
-                        whiteSpace: 'nowrap',
-                        fontSize: '12px',
-                        fontWeight: 'bold',
-                        display: 'flex',
-                        alignItems: 'center',
-                    }}>
-                        <span style={{ marginRight: '5px' }}>Copied!</span>
-                        <div style={{
-                            width: '0',
-                            height: '0',
-                            borderLeft: '10px solid yellow',
-                            borderTop: '5px solid transparent',
-                            borderBottom: '5px solid transparent',
-                            position: 'absolute',
-                            right: '-10px',
-                        }}></div>
-                    </div>
-                )} */}
             
                 {/* OPT 3 */}
                 {copied && (
@@ -128,7 +73,8 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
                         left: '-70px', // Adjusted to be closer to the right
                         transform: 'translateY(-50%)',
                         padding: '5px 10px',
-                        backgroundColor: 'yellow',
+                        color: theme.color,
+                        backgroundColor: theme.backgroundColor,
                         border: '1px solid black',
                         borderRadius: '10px',
                         boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
@@ -143,7 +89,7 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
                         <div style={{
                             width: '0',
                             height: '0',
-                            borderLeft: '10px solid yellow',
+                            borderLeft: `10px solid ${theme.color}`,
                             borderTop: '5px solid transparent',
                             borderBottom: '5px solid transparent',
                             position: 'absolute',
@@ -151,7 +97,6 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
                         }}></div>
                     </div>
                 )}
-
 
             </div>
             {/* WEB PAGE URL */}

--- a/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
+++ b/src/Components/Portfolio/AppProjectReleasesPane/SoftwareReleaseTooltip.tsx
@@ -40,7 +40,6 @@ const MyLink = styled(Link)`
 // declared using forwardRef. This opts it into receiving the ref from above as the second ref argument which is declared after props.
 const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltipProps>(({ theme, data: { command, urlText }, visible, onCopyCommand, copied }, ref) => {
     if (!visible) return null;
-
     return (
         // CONTAINER
         <div
@@ -63,7 +62,97 @@ const SoftwareReleaseTooltip = forwardRef<HTMLDivElement, SoftwareReleaseTooltip
                         {command}
                     </code>
                 </pre>
-                {copied && <span style={{ color: 'green', marginLeft: '10px' }}>Copied!</span>}
+                {/* OLD DESIGN */}
+                {/* {copied && <span style={{ color: 'green', marginLeft: '10px' }}>Copied!</span>} */}
+
+                {/* OPT 1 */}
+                {/* {copied && (
+                    <div style={{
+                        position: 'absolute',
+                        top: '-30px', // Adjust as needed
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        padding: '5px 10px',
+                        backgroundColor: 'yellow',
+                        border: '1px solid black',
+                        borderRadius: '10px',
+                        boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
+                        zIndex: 1,
+                        whiteSpace: 'nowrap',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                      }}>
+                    Copied!
+                    </div>
+                )} */}
+
+                {/* OPT 2 */}
+                {/* {copied && (
+                    <div style={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '-150px', // Adjust as needed
+                        transform: 'translateY(-50%)',
+                        padding: '5px 10px',
+                        backgroundColor: 'yellow',
+                        border: '1px solid black',
+                        borderRadius: '10px',
+                        boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
+                        zIndex: 1,
+                        whiteSpace: 'nowrap',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                        display: 'flex',
+                        alignItems: 'center',
+                    }}>
+                        <span style={{ marginRight: '5px' }}>Copied!</span>
+                        <div style={{
+                            width: '0',
+                            height: '0',
+                            borderLeft: '10px solid yellow',
+                            borderTop: '5px solid transparent',
+                            borderBottom: '5px solid transparent',
+                            position: 'absolute',
+                            right: '-10px',
+                        }}></div>
+                    </div>
+                )} */}
+            
+                {/* OPT 3 */}
+                {copied && (
+                    <div style={{
+                        position: 'absolute',
+                        // Smaller values move higher
+                        top: '27%', // Adjusted to be a bit higher
+                        // Smaller values move to the right
+                        left: '-70px', // Adjusted to be closer to the right
+                        transform: 'translateY(-50%)',
+                        padding: '5px 10px',
+                        backgroundColor: 'yellow',
+                        border: '1px solid black',
+                        borderRadius: '10px',
+                        boxShadow: '2px 2px 5px rgba(0,0,0,0.3)',
+                        zIndex: 1,
+                        whiteSpace: 'nowrap',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                        display: 'flex',
+                        alignItems: 'center',
+                    }}>
+                        <span style={{ marginRight: '5px' }}>Copied!</span>
+                        <div style={{
+                            width: '0',
+                            height: '0',
+                            borderLeft: '10px solid yellow',
+                            borderTop: '5px solid transparent',
+                            borderBottom: '5px solid transparent',
+                            position: 'absolute',
+                            right: '-10px',
+                        }}></div>
+                    </div>
+                )}
+
+
             </div>
             {/* WEB PAGE URL */}
             <div style={{

--- a/src/Components/Portfolio/PortfolioSection.stories.tsx
+++ b/src/Components/Portfolio/PortfolioSection.stories.tsx
@@ -24,30 +24,6 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
   // other properties...
   id: "arbitrary-id-not-used-by-components-in-this-DOM-scope",
   data: [
-    // PROJECT 0
-    // {
-    //   title: "Some Project",
-    //   development_period: "2020-2021",
-    //   status: "Mature",
-    //   description:
-    //     "A CLI tool to generate a Python package with a single command.",
-    //   source_code_repo: "boromir674/cookiecutter-python-package",
-    //   resource_links: [
-    //     {
-    //       url: 'https://github.com/example/repo',
-    //       type: 'github',
-    //     },
-    //   ],
-    //   release: [
-    //     {
-    //       type: "pypi",
-    //       name: "Project with 1 Artifact Released",
-    //       artifact_version: "2.4.0",
-    //       urlText: "https://pypi.org/projects/cookiecutter-python-package",
-    //     },
-    //   ],
-    //   tags: ["Python", "CLI", "Automation", "Docker"],
-    // },
     // PROJECT 1
     {
       title: "Python Package Generator",
@@ -334,10 +310,10 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
   element_to_render: defaultProps.element_to_render as FC<PortfolioLayoutItemContentProps>,
 };
 
+// STORY: Portflolio Section as a Responsive Grid with a 4 Layout Items, and Light Theme
 export const Light = {
   args: argsLight
 };
-
 
 const argsDark: ResponsiveLocalStorageLayoutProps = {
   ...argsLight,
@@ -423,6 +399,19 @@ const argsDark: ResponsiveLocalStorageLayoutProps = {
   },
 };
 
+// STORY: Portflolio Section as a Responsive Grid with a 4 Layout Items, and Dark Theme
 export const Dark = {
   args: argsDark
+};
+
+
+// STORY: Responsive Grid with 1 Layout Item that has 1 single Release Button
+export const SingleItem = {
+  args: {
+    ...argsLight,
+    data: [{
+      ...argsLight.data[0],
+      release: argsLight.data[0].release ? [argsLight.data[0].release[0]] : []
+    }],
+  }
 };

--- a/src/Components/Portfolio/PortfolioSection.stories.tsx
+++ b/src/Components/Portfolio/PortfolioSection.stories.tsx
@@ -24,6 +24,30 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
   // other properties...
   id: "arbitrary-id-not-used-by-components-in-this-DOM-scope",
   data: [
+    // PROJECT 0
+    // {
+    //   title: "Some Project",
+    //   development_period: "2020-2021",
+    //   status: "Mature",
+    //   description:
+    //     "A CLI tool to generate a Python package with a single command.",
+    //   source_code_repo: "boromir674/cookiecutter-python-package",
+    //   resource_links: [
+    //     {
+    //       url: 'https://github.com/example/repo',
+    //       type: 'github',
+    //     },
+    //   ],
+    //   release: [
+    //     {
+    //       type: "pypi",
+    //       name: "Project with 1 Artifact Released",
+    //       artifact_version: "2.4.0",
+    //       urlText: "https://pypi.org/projects/cookiecutter-python-package",
+    //     },
+    //   ],
+    //   tags: ["Python", "CLI", "Automation", "Docker"],
+    // },
     // PROJECT 1
     {
       title: "Python Package Generator",
@@ -209,23 +233,30 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
   ],
   // THEME - Styles - Colors
   theme: {
-
     // OUTER MOST element of 'Portfolio Section Header' + 'Portfolio Projects Interactive Grid'
-    container: lightTheme.portfolio.container,  // Portfolio Section Container
+    container: lightTheme.portfolio.container, // Portfolio Section Container
 
     // HEADER with Title; ie 'Open Source & Portfolio'
-    sectionHeader: lightTheme.portfolio.sectionHeader,  // Portfolio Section Header
+    sectionHeader: lightTheme.portfolio.sectionHeader, // Portfolio Section Header
+
+    // Reset Layout - Button
+    resetLayoutButton: lightTheme.portfolio.resetLayoutButton,
 
     // Portfolio Project Item
     item: {
       // outline:
       outline: `${lightTheme.portfolio.item.outline.width} solid ${lightTheme.portfolio.item.outline.color}`,
-      backgroundColor: lightTheme.portfolio.item.backgroundColor,  // not used
-      color: lightTheme.portfolio.item.color,  // Project Header color css property
+      backgroundColor: lightTheme.portfolio.item.backgroundColor, // not used
+      color: lightTheme.portfolio.item.color, // Project Header color css property
       theme: {
-        // Releases Pane
+        // Project Title
+        projectTitle: lightTheme.portfolio.item.projectTitle,
+        // Project Description
+        projectDescription: lightTheme.portfolio.item.projectDescription,
+        // Project Releases Pane
         releases: {
           headerFontFamily: lightTheme.portfolio.item.releases.fontFamily,
+          headerFontSize: lightTheme.portfolio.item.releases.headerFontSize,
           headerColor: lightTheme.portfolio.item.releases.color,
           headerMarginBottom: lightTheme.portfolio.item.releases.headerMarginBottom,
           releaseButtonTheme: {
@@ -256,11 +287,15 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
                 },
               },
             ],
-          }
+          },
         },
         // Project Links Pane, ie source code repo docs, etc
         links: {
           headerColor: lightTheme.portfolio.item.resourceLinks.headerColor,
+          header: {
+            fontFamily: lightTheme.portfolio.item.resourceLinks.header.fontFamily,
+            fontSize: lightTheme.portfolio.item.resourceLinks.header.fontSize,
+          },
           item: {
             ...lightTheme.portfolio.item.resourceLinks.item,
             icons: [
@@ -289,8 +324,8 @@ const argsLight: ResponsiveLocalStorageLayoutProps = {
                 },
               },
             ],
-          }
-        }
+          },
+        },
       }
     },
   },
@@ -347,6 +382,7 @@ const argsDark: ResponsiveLocalStorageLayoutProps = {
         },
         links: {
           headerColor: darkTheme.portfolio.item.resourceLinks.headerColor,
+          header: darkTheme.portfolio.item.resourceLinks.header,
           item: {
             ...darkTheme.portfolio.item.resourceLinks.item,
             icons: [
@@ -373,6 +409,14 @@ const argsDark: ResponsiveLocalStorageLayoutProps = {
               },
             ],
           }
+        },
+        projectTitle: {
+          fontFamily: "",
+          fontSize: undefined
+        },
+        projectDescription: {
+          fontFamily: "",
+          fontSize: ""
         }
       }
     },

--- a/src/Components/Portfolio/PortfolioSection.tsx
+++ b/src/Components/Portfolio/PortfolioSection.tsx
@@ -221,7 +221,6 @@ const ResponsiveLocalStorageLayout: FC<ResponsiveLocalStorageLayoutProps> = ({
     layoutItem: LayoutInterface,
     placeholder: LayoutInterface,
   ) => {
-    console.log("RESIZE HAPPENED");
     if (layoutItem.w <= 2) {
       const newValue = layoutItem.h + 2;
       // modifying `layoutItem` to enforce constraints
@@ -266,8 +265,6 @@ const ResponsiveLocalStorageLayout: FC<ResponsiveLocalStorageLayoutProps> = ({
     saveToLS("layouts", allLayouts);
     // we store the layouts in the component's state, and trigger a re-render
     setLayouts(allLayouts);
-    // log in console a formatted string to show the current layout
-    console.log("ANY LAYOUTS Change HAPPENED");
   };
 
   // CONSTANT: starting width of each Portfolio Item

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,5 +13,5 @@ export default IndexPage;
 
 // the HeadFC Component allows to alter the <head> html element or insert elements in it
 
-// ADD content of the <head> element mostly used for metadata nd SEO
+// ADD content of the <head> element mostly used for metadata and SEO
 export const Head: HeadFC = () => <SEO />;

--- a/src/theme/AppStyles.ts
+++ b/src/theme/AppStyles.ts
@@ -340,8 +340,5 @@ interface ComputedTheme extends Theme {
 }
 
 
-
-
-
 // export { type ComputedTheme, type Theme, mergeStylings, commonStyling };
 export { type ComputedTheme, type Theme };


### PR DESCRIPTION
- ci(cloudfront): properly invalidate Cloudfront Distribution
- refactor: clean code; remove console.log statement
- clean CI/CD Pipeline Yaml Workflow
- add comments in e2e docker-compose
- fix: Eco Development Exp Item Duration data
- slitgly improve the Portfolio Data
- ci: improve inputs description for Headless Lighthouse Reusable Workflow
- install make in Dev Container and run 'yarn install' at post Start
- update Portfolio Section Story
- feat: copy to clipboard on shell command click
- add new story to examine Single Release Button inside a Reactive Grid
- refactor: document ResponsiveLocalStorageLayout and ResponsiveReactGridLayout rendered
- feat: simple Copied pop-up on shell cmd user copy
- refactor: remove console.log statements
- feat: use app Theme for color styles of Copy pop-up
- ci: accept 2.5MB of prod build Bundle Size; a 4.17% increase from previous 2.4MB
- docs: add Changelog entry for v1.10.0 Release
- semver: bump sem ver to 1.10.0 in package.json
